### PR TITLE
Microtransactions: Prevent PHP warning because steamurl isn't provided by Steam API.

### DIFF
--- a/class/transactions.php
+++ b/class/transactions.php
@@ -544,7 +544,9 @@ class transactions {
         if ($CURLResponse->response->result == "OK") {
             $this->transid = $CURLResponse->response->params->transid;
             $this->orderid = $CURLResponse->response->params->orderid;
-            $this->steamurl = $CURLResponse->response->params->steamurl;
+            if(isset($CURLResponse->response->params->steamurl)) {
+                $this->steamurl = $CURLResponse->response->params->steamurl;
+            }
             return $this;
         }
 


### PR DESCRIPTION
A PHP warning will show up when initiating a transaction using `InitTxn` when `usersession` is set to `client`. The warning is because the `steamurl` isn't provided in the response when `usersession` is `client`.

This PR will check if `steamurl` is provided before trying to access it to prevent the warning from showing up.